### PR TITLE
First shot at Dockerizing + getMacLinux() function fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+FROM debian:stretch
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV container docker
+ENV init /lib/systemd/systemd
+ENV LC_ALL C
+
+RUN apt-get update && apt-get -y install procps less systemd ; \
+    [ -e /lib/systemd/system/sysinit.target.wants/ ] && \
+      find /lib/systemd/system/sysinit.target.wants/ ! -name 'systemd-tmpfiles-setup.service' -type f -o -type l -exec rm -f {} \; || true; \
+    [ -e /lib/systemd/system/local-fs.target.wants/ ] && \
+      find /lib/systemd/system/multi-user.target.wants/ -type f -o -type l -exec rm -f {} \; || true; \
+    find /etc/systemd/system/*.wants/ -type f -o -type l -exec rm -f {} \; || true; \
+    [ -e /lib/systemd/system/local-fs.target.wants/ ] && \
+      find /lib/systemd/system/local-fs.target.wants/ -type f -o -type l -exec rm -f {} \; || true; \
+    [ -e /lib/systemd/system/sockets.target.wants/ ] && \
+      find /lib/systemd/system/sockets.target.wants/ -iname '*udev*' -o -iname '*initctl*' -exec rm -f {} \; || true; \
+    [ -e /usr/lib/tmpfiles.d/systemd-nologin.conf ] && rm -f /usr/lib/tmpfiles.d/systemd-nologin.conf || true
+
+RUN sed -i'' -e 's/.*SystemMaxUse=.*/SystemMaxUse=500M/' /etc/systemd/journald.conf ; \
+    mkdir -p /usr/local/lib/systemd/system
+
+ADD docker/systemd/minera.service /usr/local/lib/systemd/system/
+
+RUN ln -s /usr/local/lib/systemd/system/minera.service /etc/systemd/system/multi-user.target.wants/minera.service
+
+RUN printf '# Do not install recommended and suggested packages by default\n\
+APT::Install-Recommends "0";\n\
+APT::Install-Suggests "0";\n' > /etc/apt/apt.conf.d/docker-skip-recommends-suggests
+
+RUN apt-get update && apt-get install -y lighttpd php5-cgi
+RUN lighty-enable-mod fastcgi
+RUN lighty-enable-mod fastcgi-php
+
+RUN mkdir -p /etc/systemd/system/lighttpd.service.d/
+ADD docker/systemd/lighttpd.conf /etc/systemd/system/lighttpd.service.d/lighttpd.conf
+ADD docker/lighttpd/conf-available/15-fastcgi-php.conf /etc/lighttpd/conf-available/15-fastcgi-php.conf
+
+RUN apt-get install -y curl screen php5-cli php5-curl
+RUN echo "postfix postfix/main_mailer_type string 'Internet site'" >> preseed.txt; \
+    echo "postfix postfix/mailname string mail.example.com" >> preseed.txt; \
+    debconf-set-selections preseed.txt && rm preseed.txt
+
+ADD . /var/www/minera
+RUN apt-get -y install build-essential pkg-config file libbase58-dev libjansson-dev && cd /var/www/minera/minera-bin/src/libblkmaker/ && ./configure && make || true; \
+    cd /var/www/minera && sed -e 's/^[[:space:]]*sudo//' -e '/nvm/d; /NVM/d' ./install_minera.sh | /bin/bash && \
+    apt-get -y purge build-essential redis-server && \
+    dpkg-query  --show --showformat='${binary:Package}\n' | grep '\-dev$' | xargs apt-get purge -y && \
+    apt-get -y autoremove --purge && \
+    apt-get -y install npm nodejs-legacy nodejs redis-tools && apt-mark manual npm nodejs-legacy nodejs redis-tools && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN [ -e /etc/systemd/system/default.target ] && rm /etc/systemd/system/default.target || true ; \
+    ln -s /usr/lib/systemd/system/multi-user.target /etc/systemd/system/default.target
+
+#RUN systemctl set-default multi-user.target
+
+
+VOLUME [ "/sys/fs/cgroup" ]
+# Workaround hack for missing /sys/fs/cgroup (This works on Docker Machine, but YMMV)
+CMD ["/bin/bash", "-c", "mount -oremount,rw /sys/fs/cgroup; mkdir /sys/fs/cgroup/systemd; mount -oremount,ro /sys/fs/cgroup; exec /lib/systemd/systemd"]
+
+# TODO: If possible, somehow cleanup above hack, & replace with either:
+#ENTRYPOINT ["/lib/systemd/systemd"]
+#CMD ["/usr/sbin/init"]

--- a/application/config/redis.php
+++ b/application/config/redis.php
@@ -6,10 +6,16 @@
  */
 
 // Default connection group
-$config['redis_default']['host'] = 'localhost';		// IP address or host
+if ( array_key_exists("container", $_SERVER)  && $_SERVER["container"] == "docker" ) {
+  $config['redis_default']['host'] = 'redis';		        // Use linked 'redis' container if inside docker
+} else {
+  $config['redis_default']['host'] = 'localhost';		// IP address or host
+}
+
 $config['redis_default']['port'] = '6379';			// Default Redis port is 6379
 $config['redis_default']['password'] = '';			// Can be left empty when the server does not require AUTH
 
 $config['redis_slave']['host'] = '';
 $config['redis_slave']['port'] = '6379';
 $config['redis_slave']['password'] = '';
+

--- a/application/models/util_model.php
+++ b/application/models/util_model.php
@@ -2032,12 +2032,9 @@ class Util_model extends CI_Model {
 			$iface = array();
 			foreach($result as $key => $line) {
 				if($key > 0) {
-					$tmp = str_replace(" ", "", substr($line, 0, 10));
-					if($tmp <> "") {
-						$macpos = strpos($line, "HWaddr");
-						if($macpos !== false) {
-							$iface[] = array('iface' => $tmp, 'mac' => strtolower(substr($line, $macpos+7, 17)));
-						}
+					if (preg_match('/\s*(([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2}))\s*/', $line, $matches)) {
+						//var_dump($matches);
+						$iface[] = array('mac' => $matches[1]);
 					}
 				}
 		    }

--- a/application/models/util_model.php
+++ b/application/models/util_model.php
@@ -2032,7 +2032,7 @@ class Util_model extends CI_Model {
 			$iface = array();
 			foreach($result as $key => $line) {
 				if($key > 0) {
-					if (preg_match('/\s*(([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2}))\s*/', $line, $matches)) {
+					if (preg_match('/\s*(([0-9A-Fa-f]{1,2}[:-]){5}([0-9A-Fa-f]{1,2}))\s*/', $line, $matches)) {
 						//var_dump($matches);
 						$iface[] = array('mac' => $matches[1]);
 					}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t trinitronx/minera .

--- a/docker/lighttpd/conf-available/15-fastcgi-php.conf
+++ b/docker/lighttpd/conf-available/15-fastcgi-php.conf
@@ -1,0 +1,20 @@
+# -*- depends: fastcgi -*-
+# /usr/share/doc/lighttpd/fastcgi.txt.gz
+# http://redmine.lighttpd.net/projects/lighttpd/wiki/Docs:ConfigurationOptions#mod_fastcgi-fastcgi
+
+## Start an FastCGI server for php (needs the php5-cgi package)
+fastcgi.server += ( ".php" => 
+	((
+		"bin-path" => "/usr/bin/php-cgi",
+		"socket" => "/var/run/lighttpd/php.socket",
+		"max-procs" => 1,
+		"bin-environment" => ( 
+			"PHP_FCGI_CHILDREN" => "4",
+			"PHP_FCGI_MAX_REQUESTS" => "10000"
+		),
+		"bin-copy-environment" => (
+			"PATH", "SHELL", "USER", "container"
+		),
+		"broken-scriptfilename" => "enable"
+	))
+)

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#if docker ps -a | grep -q redis; then
+#  docker kill redis; docker rm -v redis
+#fi
+
+#docker run  --name redis -d redis
+docker run --rm --link redis -e container=docker --cap-add SYS_ADMIN --privileged  -it -v /run -v /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+  -p 443:443 \
+  -p 80:80 \
+  trinitronx/minera
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,5 +8,6 @@
 docker run --rm --link redis -e container=docker --cap-add SYS_ADMIN --privileged  -it -v /run -v /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
   -p 443:443 \
   -p 80:80 \
+  -p 4200:4200 \
   trinitronx/minera
 

--- a/docker/systemd/lighttpd.conf
+++ b/docker/systemd/lighttpd.conf
@@ -1,0 +1,3 @@
+[Service]
+Environment=container=docker
+

--- a/docker/systemd/minera.service
+++ b/docker/systemd/minera.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Minera Node.js Service
+After=mdns.service
+
+[Service]
+#EnvironmentFile=/var/www/minera/server/.env
+User=minera
+Environment=NODE_ENV=production
+Environment=container=docker
+Environment=NODE_PATH=/usr/lib/node_modules/:/var/www/minera/server/node_modules
+WorkingDirectory=/var/www/minera/server
+ExecStartPre=-/usr/bin/npm install
+ExecStart=/usr/bin/node index.js
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=default.target

--- a/server/index.js
+++ b/server/index.js
@@ -4,10 +4,23 @@
 //		To be served from getminera.com website
 /************************************************/
 
-var redis = require('redis'),
-    client = redis.createClient(),
-    request = require('request'),
-    apiUrl = 'https://getminera.com/api';
+ 
+// Detect if running in docker and use linked 'redis' container
+// TODO: Support ENV vars for configurability?
+switch(process.env.container) {
+  case 'docker':
+    var redis = require('redis'),
+        client = redis.createClient({"url": "redis://redis"}),
+        request = require('request'),
+        apiUrl = 'https://getminera.com/api';
+    break;
+  default:
+    var redis = require('redis'),
+        client = redis.createClient(),
+        request = require('request'),
+        apiUrl = 'https://getminera.com/api';
+    break;
+}
 
 client.subscribe('minera-channel');
 


### PR DESCRIPTION
Changes:
- Created `Dockerfile` to install & get `debian:stretch` `SystemD`-based docker container with Minera up and running, found and fixed the following issue:
- Fixed `getMacLinux()` function to always return first thing that looks like a MAC address from `netstat -ie` output.  ([Some Unix\* flavors](http://www.coffer.com/mac_info/locate-unix.html) do not always have `HWAddr` or `ether` in front, so pattern matching works best).
- Detect if running inside docker via the `container=docker` environment variable (must be set for SystemD to work inside Docker)
- Use an external linked container named '`redis`'  (for future Redis cluster scalability & ability to start / stop the Minera container independently while leaving up `redis` container to save Redis data)

If you appreciate the work, I do accept tips: [![Gratipay](http://img.shields.io/gratipay/trinitronx.svg)](https://www.gratipay.com/trinitronx)
